### PR TITLE
MF-341 Correct ley flag

### DIFF
--- a/src/SFA.DAS.Reservations.Data/Repository/AccountLegalEntityRepository.cs
+++ b/src/SFA.DAS.Reservations.Data/Repository/AccountLegalEntityRepository.cs
@@ -20,6 +20,13 @@ namespace SFA.DAS.Reservations.Data.Repository
         {
             using (var transaction = _dataContext.Database.BeginTransaction())
             {
+                var existingLevyStatus = await _dataContext
+                    .AccountLegalEntities
+                    .Where(c => c.AccountId.Equals(accountLegalEntity.AccountId))
+                    .AnyAsync(c=>c.IsLevy);
+
+                accountLegalEntity.IsLevy = existingLevyStatus;
+
                 await _dataContext.AccountLegalEntities.AddAsync(accountLegalEntity);
                 _dataContext.SaveChanges();
                 transaction.Commit();


### PR DESCRIPTION
Corrected the way that the levy flag is set for when there is already
an existing legal entity that is levy. If it is levy then the default
`IsLevy = false` is overwritten with what has already been set.