### PR TITLE
Add default index

### DIFF
--- a/src/SFA.DAS.Reservations.Data/Registry/IndexRegistry.cs
+++ b/src/SFA.DAS.Reservations.Data/Registry/IndexRegistry.cs
@@ -47,8 +47,9 @@ namespace SFA.DAS.Reservations.Data.Registry
             var indicesToDelete = indices.Documents.Where(x =>
                 x.DateCreated <= DateTime.Now.AddDays(-daysOld)).ToArray();
 
+            if (!indicesToDelete.Any()) return;
+            
             await _client.DeleteManyAsync(indicesToDelete, Name);
-
         }
 
         private void SetCurrentIndexName()

--- a/src/SFA.DAS.Reservations.Functions.ProviderPermission/Startup.cs
+++ b/src/SFA.DAS.Reservations.Functions.ProviderPermission/Startup.cs
@@ -105,7 +105,7 @@ namespace SFA.DAS.Reservations.Functions.ProviderPermission
             services.AddTransient<IReservationIndexRepository, ReservationIndexRepository>();
             services.AddTransient<IIndexRegistry, IndexRegistry>();
 
-            services.AddElasticSearch(config);
+            services.AddElasticSearch(config, Configuration["EnvironmentName"]);
 
             services.AddSingleton(new ReservationJobsEnvironment(Configuration["EnvironmentName"]));
             services.AddTransient<IProviderPermissionsUpdatedHandler, ProviderPermissionsUpdatedHandler>();

--- a/src/SFA.DAS.Reservations.Functions.ReservationIndex/Startup.cs
+++ b/src/SFA.DAS.Reservations.Functions.ReservationIndex/Startup.cs
@@ -99,7 +99,7 @@ namespace SFA.DAS.Reservations.Functions.ReservationIndex
             services.AddTransient<IProviderPermissionRepository,ProviderPermissionRepository>();
             services.AddTransient<IIndexRegistry,IndexRegistry>();
 
-            services.AddElasticSearch(config);
+            services.AddElasticSearch(config, Configuration["EnvironmentName"]);
             services.AddSingleton(new ReservationJobsEnvironment(Configuration["EnvironmentName"]));
 
             services.AddDbContext<ReservationsDataContext>(options => options.UseSqlServer(config.ConnectionString));

--- a/src/SFA.DAS.Reservations.Functions.Reservations/Startup.cs
+++ b/src/SFA.DAS.Reservations.Functions.Reservations/Startup.cs
@@ -137,7 +137,7 @@ namespace SFA.DAS.Reservations.Functions.Reservations
 
             services.AddTransient<IIndexRegistry, IndexRegistry>();
 
-            services.AddElasticSearch(jobsConfig);
+            services.AddElasticSearch(jobsConfig, Configuration["EnvironmentName"]);
             services.AddSingleton(new ReservationJobsEnvironment(Configuration["EnvironmentName"]));
 
             var clientFactory = serviceProvider.GetService<IHttpClientFactory>();

--- a/src/SFA.DAS.Reservations.Infrastructure/ElasticSearch/ServiceCollectionExtension.cs
+++ b/src/SFA.DAS.Reservations.Infrastructure/ElasticSearch/ServiceCollectionExtension.cs
@@ -3,16 +3,21 @@ using Elasticsearch.Net;
 using Microsoft.Extensions.DependencyInjection;
 using Nest;
 using SFA.DAS.Reservations.Domain.Configuration;
+using SFA.DAS.Reservations.Domain.Reservations;
 
 namespace SFA.DAS.Reservations.Infrastructure.ElasticSearch
 {
     public static class ServiceCollectionExtension
     {
-        public static void AddElasticSearch(this ServiceCollection collection, ReservationsJobs configuration)
+        public static void AddElasticSearch(
+            this ServiceCollection collection,
+            ReservationsJobs configuration, 
+            string environmentName)
         {
             var connectionPool = new SingleNodeConnectionPool(new Uri(configuration.ElasticSearchServerUrl));
 
             var settings = new ConnectionSettings(connectionPool);
+            settings.DefaultMappingFor<IndexedReservation>(descriptor => descriptor.IndexName($"{environmentName}-reservations"));
 
             if (!string.IsNullOrEmpty(configuration.ElasticSearchUsername) &&
                 !string.IsNullOrEmpty(configuration.ElasticSearchPassword))


### PR DESCRIPTION
stops error 
```
Index name is null for the given type and no default index is set. Map an index name using ConnectionSettings.DefaultMappingFor<TDocument>() or set a default index using ConnectionSettings.DefaultIndex().
```