### PR TITLE
MF-380 - Added check stop update if no permissions found

### DIFF
--- a/src/SFA.DAS.Reservations.Application.UnitTests/Reservations/Services/WhenAddingReservationToReservationsIndex.cs
+++ b/src/SFA.DAS.Reservations.Application.UnitTests/Reservations/Services/WhenAddingReservationToReservationsIndex.cs
@@ -67,5 +67,24 @@ namespace SFA.DAS.Reservations.Application.UnitTests.Reservations.Services
                 actualReservation.IsLevyAccount.Should().Be(false);
             }
         }
+
+         [Test, MoqAutoData]
+        public async Task Then_If_No_Provider_Permissions_Found_Does_Not_Update_Index(
+            Reservation reservation,
+            [Frozen] Mock<IProviderPermissionRepository> mockPermissionsRepo,
+            [Frozen] Mock<IReservationIndexRepository> mockIndexRepo,
+            ReservationService service)
+        {
+            //Arrange
+            mockPermissionsRepo
+                .Setup(repository => repository.GetAllForAccountLegalEntity(reservation.AccountLegalEntityId))
+                .Returns(new List<Domain.Entities.ProviderPermission>());
+            
+            //Act
+            await service.AddReservationToReservationsIndex(reservation);
+          
+            //Assert
+            mockIndexRepo.Verify(r => r.Add(It.IsAny<IEnumerable<IndexedReservation>>()), Times.Never);
+        }
     }
 }

--- a/src/SFA.DAS.Reservations.Application/Reservations/Services/ReservationService.cs
+++ b/src/SFA.DAS.Reservations.Application/Reservations/Services/ReservationService.cs
@@ -89,10 +89,15 @@ namespace SFA.DAS.Reservations.Application.Reservations.Services
         {
             _logger.LogInformation($"Adding Reservation Id [{reservation.Id}] to index.");
 
-            var permissions = _permissionsRepository.GetAllForAccountLegalEntity(reservation.AccountLegalEntityId);
-            
-            _logger.LogInformation($"[{permissions.Count()}] providers found for Reservation Id [{reservation.Id}].");
-            
+            var permissions = _permissionsRepository.GetAllForAccountLegalEntity(reservation.AccountLegalEntityId).ToArray();
+
+            _logger.LogInformation($"[{permissions.Length}] providers found for Reservation Id [{reservation.Id}].");
+
+            if (!permissions.Any())
+            {
+                return;
+            }
+
             var indexedReservations = new List<IndexedReservation>();
             foreach (var providerPermission in permissions)
             {

--- a/src/SFA.DAS.Reservations.Functions.Reservations/Startup.cs
+++ b/src/SFA.DAS.Reservations.Functions.Reservations/Startup.cs
@@ -147,7 +147,6 @@ namespace SFA.DAS.Reservations.Functions.Reservations
                 services.AddTransient<IEncodingService, EncodingService>();
                 services.AddTransient<IReservationIndexRepository, ReservationIndexRepository>();
                 services.AddTransient<IProviderPermissionRepository, ProviderPermissionRepository>();
-                services.AddTransient<IReservationCreatedHandler, IReservationCreatedHandler>();
                 services.AddTransient<IAccountsService, AccountsService>();
                 services.AddTransient<INotificationTokenBuilder, NotificationTokenBuilder>();
             }


### PR DESCRIPTION
If no provider permissions are returned we do not update the reservation index.