### PR TITLE
CON-4340 Re-enabling lazy loading on the db context. At least one iss…

### DIFF
--- a/src/SFA.DAS.Reservations.Data/ReservationsDataContext.cs
+++ b/src/SFA.DAS.Reservations.Data/ReservationsDataContext.cs
@@ -41,7 +41,7 @@ namespace SFA.DAS.Reservations.Data
         public ReservationsDataContext(DbContextOptions options) : base(options)
         {
         }
-        
+
         public ReservationsDataContext(DbContextOptions<ReservationsDataContext> options, IDbConnection connection) : base(options)
         {
             _connection = connection;
@@ -53,10 +53,8 @@ namespace SFA.DAS.Reservations.Data
             {
                 optionsBuilder.UseSqlServer(_connection as DbConnection, options => options.EnableRetryOnFailure(3));
             }
-            else
-            {
-                optionsBuilder.UseLazyLoadingProxies();
-            }
+
+            optionsBuilder.UseLazyLoadingProxies();
         }
 
         public override int SaveChanges()


### PR DESCRIPTION
…ue with this being disabled where course isn't loaded when fetching reservations for indexing. It would seem that, before the MI work was done, this was enabled by default